### PR TITLE
GNU vs BSD stat: incompatible flags

### DIFF
--- a/rake_completion.plugin.zsh
+++ b/rake_completion.plugin.zsh
@@ -4,18 +4,9 @@
 #
 # Wanted it in a plugin so I could use it now that I've switched to zgen
 
-_rake_does_task_list_need_generating () {
-  if [ ! -f .rake_tasks ]; then return 0;
-  else
-    accurate=$(stat -f%m .rake_tasks)
-    changed=$(stat -f%m Rakefile)
-    return $(expr $accurate '>=' $changed)
-  fi
-}
-
 _rake () {
   if [ -f Rakefile ]; then
-    if _rake_does_task_list_need_generating; then
+    if [[ ! -f .rake_tasks || Rakefile -nt .rake_tasks ]]; then
       echo "\nGenerating .rake_tasks..." > /dev/stderr
       rake --silent --tasks | cut -d " " -f 2 > .rake_tasks
     fi


### PR DESCRIPTION
BSD stat has a `-f` flag, but in GNU stat it is `-c`.

Instead of mucking around with stat, just use ZSH comparisons.